### PR TITLE
Updated implementation of middleware

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -33,8 +33,8 @@ impl PostgresMiddleware {
 
 impl Key for PostgresMiddleware { type Value = Arc<Pool<PostgresConnectionManager>>; }
 
-impl Middleware for PostgresMiddleware {
-    fn invoke<'a>(&self, req: &mut Request, res: Response<'a>) -> MiddlewareResult<'a> {
+impl<D> Middleware<D> for PostgresMiddleware {
+    fn invoke<'mw, 'conn>(&self, req: &mut Request<'mw, 'conn, D>, res: Response<'mw, D>) -> MiddlewareResult<'mw, D> {
         req.extensions_mut().insert::<PostgresMiddleware>(self.pool.clone());
         Ok(Continue(res))
     }
@@ -44,7 +44,7 @@ pub trait PostgresRequestExtensions {
     fn db_conn(&self) -> PooledConnection<PostgresConnectionManager>;
 }
 
-impl<'a, 'b, 'c> PostgresRequestExtensions for Request<'a, 'b, 'c> {
+impl<'a, 'b> PostgresRequestExtensions for Request<'a, 'b> {
     fn db_conn(&self) -> PooledConnection<PostgresConnectionManager> {
         self.extensions().get::<PostgresMiddleware>().unwrap().get().unwrap()
     }


### PR DESCRIPTION
Builds failed from Cargo and I was unable to compile this with Rust 1.3.0, Nickel 0.7.0, r2d2 0.6.0, and r2d2_postgres 0.9.3.

These changes got the build working again, but I'm not sure if there is a larger integration test at hand to ensure it is correct.