### PR TITLE
fix SslMode

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 use std::error::Error as StdError;
 
 use nickel::{Request, Response, Middleware, Continue, MiddlewareResult};
-use postgres::{SslMode};
-use r2d2_postgres::{PostgresConnectionManager};
+use r2d2_postgres::{PostgresConnectionManager, SslMode};
 use r2d2::{Pool, HandleError, Config, PooledConnection};
 use typemap::Key;
 use plugin::{Pluggable, Extensible};


### PR DESCRIPTION
I guess r2d2_postgres uses `r2d2_postgres::SslMode`, not `postgres::SslMode` 
```
/Users/shinriyo/.multirust/toolchains/stable/cargo/git/checkouts/nickel-postgres-f47cd59392fbdedc/master/src/middleware.rs:21:72: 21:80 error: mismatched types:
 expected `r2d2_postgres::SslMode`,
    found `postgres::SslMode<'_>`
(expected enum `r2d2_postgres::SslMode`,
    found enum `postgres::SslMode`) [E0308]
/Users/shinriyo/.multirust/toolchains/stable/cargo/git/checkouts/nickel-postgres-f47cd59392fbdedc/master/src/middleware.rs:21         let manager = try!(PostgresConnectionManager::new(connect_str, ssl_mode));
                                                                                                                                                                                                     ^~~~~~~~
/Users/shinriyo/.multirust/toolchains/stable/cargo/git/checkouts/nickel-postgres-f47cd59392fbdedc/master/src/middleware.rs:21:23: 21:82 note: in this expansion of try! (defined in <std macros>)
/Users/shinriyo/.multirust/toolchains/stable/cargo/git/checkouts/nickel-postgres-f47cd59392fbdedc/master/src/middleware.rs:21:72: 21:80 help: run `rustc --explain E0308` to seeuse std::sync::Arc;
 a detailed explanation
error: aborting due to previous error
Could not compile `nickel_postgres`.
```