### PR TITLE
Refactor middleware interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,14 @@
 [package]
 
 name = "nickel_postgres"
-version = "0.0.0"
+version = "0.2.0"
 authors = [
     "bguiz"
 ]
 
 [dependencies]
-postgres = "*"
-r2d2 = "*"
-r2d2_postgres = "*"
-plugin = "*"
-typemap = "*"
-openssl = "*"
-nickel = "*"
+nickel = "0.8.1"
+r2d2 = "0.7.0"
+r2d2_postgres = "0.10.1"
+typemap = "0.3.3"
+plugin = "0.2.6"

--- a/examples/with_pool.rs
+++ b/examples/with_pool.rs
@@ -1,7 +1,11 @@
+extern crate r2d2;
+extern crate r2d2_postgres;
 #[macro_use] extern crate nickel;
 extern crate nickel_postgres;
 
 use std::env;
+use r2d2::{Config, Pool};
+use r2d2_postgres::{PostgresConnectionManager, SslMode};
 use nickel::{Nickel, HttpRouter};
 use nickel_postgres::{PostgresMiddleware, PostgresRequestExtensions};
 
@@ -9,8 +13,13 @@ fn main() {
     let mut app = Nickel::new();
 
     let postgres_url = env::var("DATABASE_URL").unwrap();
-    let mw = PostgresMiddleware::new(&postgres_url).unwrap();
-    app.utilize(mw);
+    let db_mgr = PostgresConnectionManager::new(postgres_url.as_ref(), SslMode::None)
+        .expect("Unable to connect to database");
+
+    let db_pool = Pool::new(Config::default(), db_mgr)
+        .expect("Unable to initialize connection pool");
+
+    app.utilize(PostgresMiddleware::with_pool(db_pool));
 
     app.get("/my_counter", middleware! { |request, response|
         let _connection = try_with!(response, request.pg_conn());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 extern crate nickel;
-extern crate postgres;
 extern crate r2d2;
 extern crate r2d2_postgres;
-extern crate plugin;
 extern crate typemap;
+extern crate plugin;
 
 pub use middleware::{ PostgresMiddleware, PostgresRequestExtensions };
 


### PR DESCRIPTION
BREAKING CHANGES - bumps the crate to 0.2.0

- Remove Arc wrapper around the Pool. The Pool internally handles this.
- PostgresMiddleware::new() now only accepts a Postgres URL and uses
  sensible defaults to setup the connection pool.
- Add PostgresMiddleware::with_pool() to accept an already connected
  pool when creating the middleware.
- Rename db_conn() to pg_conn(). This method is now safer and provides
  more a better error message if used without first registering the
  middleware.
- Original example has been updated to reflect these changes. A new
  example has been added to show how with_pool() works.
