### PR TITLE
Update nickel version to stop errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ keywords = ["nickel", "postgres", "database", "web"]
 [dependencies]
 nickel = "0.9"
 r2d2 = "0.7.0"
-r2d2_postgres = "0.10.1"
+r2d2_postgres = "0.11"
 typemap = "0.3.3"
 plugin = "0.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 keywords = ["nickel", "postgres", "database", "web"]
 
 [dependencies]
-nickel = "0.8.1"
+nickel = "0.9"
 r2d2 = "0.7.0"
 r2d2_postgres = "0.10.1"
 typemap = "0.3.3"

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::result::Result;
 use nickel::{Request, Response, Middleware, Continue, MiddlewareResult};
 use nickel::status::StatusCode;
-use r2d2_postgres::{PostgresConnectionManager, SslMode};
+use r2d2_postgres::{PostgresConnectionManager, TlsMode};
 use r2d2::{Config, Pool, PooledConnection, GetTimeout};
 use typemap::Key;
 use plugin::Extensible;
@@ -16,7 +16,7 @@ impl PostgresMiddleware {
     ///
     /// The middleware will be setup with no ssl and the r2d2 defaults.
     pub fn new(db_url: &str) -> Result<PostgresMiddleware, Box<Error>> {
-        let manager = try!(PostgresConnectionManager::new(db_url, SslMode::None));
+        let manager = try!(PostgresConnectionManager::new(db_url, TlsMode::None));
         let pool = try!(Pool::new(Config::default(), manager));
 
         Ok(PostgresMiddleware { pool: pool })


### PR DESCRIPTION
When using in a project which has a dependency of Nickel `0.9`, I got errors about a missing trait:

```
error[E0277]: the trait bound `for<'r, 'mw, 'conn> nickel_postgres::PostgresMiddleware:
    std::ops::Fn<(&'r mut nickel::Request<'mw, 'conn>, nickel::Response<'mw>)>` is not satisfied
```

This seems to be because `nickel_postgres` has a dependency on `0.8.1`, which is incompatible with `0.9` - updating the dependency in `nickel_postgres` fixes the error and allows the project to compile.
