### PR TITLE
Removed deprecated libraries.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "nickel_postgres"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "bguiz"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "nickel_postgres"
-version = "0.2.1"
+version = "0.3.0"
 authors = [
     "bguiz"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 keywords = ["nickel", "postgres", "database", "web"]
 
 [dependencies]
-nickel = "0.8.1"
+nickel = "0.11.0"
 r2d2 = "0.8.5"
 r2d2_postgres = "0.14.0"
 typemap = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["nickel", "postgres", "database", "web"]
 
 [dependencies]
 nickel = "0.8.1"
-r2d2 = "0.7.0"
-r2d2_postgres = "0.10.1"
+r2d2 = "0.8.5"
+r2d2_postgres = "0.14.0"
 typemap = "0.3.3"
 plugin = "0.2.6"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,9 +1,10 @@
-#[macro_use] extern crate nickel;
+#[macro_use]
+extern crate nickel;
 extern crate nickel_postgres;
 
-use std::env;
-use nickel::{Nickel, HttpRouter};
+use nickel::{HttpRouter, Nickel};
 use nickel_postgres::{PostgresMiddleware, PostgresRequestExtensions};
+use std::env;
 
 fn main() {
     let mut app = Nickel::new();
@@ -12,11 +13,14 @@ fn main() {
     let mw = PostgresMiddleware::new(&postgres_url).unwrap();
     app.utilize(mw);
 
-    app.get("/my_counter", middleware! { |request, response|
-        let _connection = try_with!(response, request.pg_conn());
+    app.get(
+        "/my_counter",
+        middleware! { |request, response|
+            let _connection = try_with!(response, request.pg_conn());
 
-        // use connection
-    });
+            // use connection
+        },
+    );
 
     app.get("**", middleware! { println!("!!!") });
 }

--- a/examples/with_pool.rs
+++ b/examples/with_pool.rs
@@ -25,7 +25,6 @@ fn main() {
         "/my_counter",
         middleware! { |request, response|
             let _connection = try_with!(response, request.pg_conn());
-
             // use connection
         },
     );

--- a/examples/with_pool.rs
+++ b/examples/with_pool.rs
@@ -1,31 +1,34 @@
 extern crate r2d2;
 extern crate r2d2_postgres;
-#[macro_use] extern crate nickel;
+#[macro_use]
+extern crate nickel;
 extern crate nickel_postgres;
 
-use std::env;
-use r2d2::{Config, Pool};
-use r2d2_postgres::{PostgresConnectionManager, SslMode};
-use nickel::{Nickel, HttpRouter};
+use nickel::{HttpRouter, Nickel};
 use nickel_postgres::{PostgresMiddleware, PostgresRequestExtensions};
+use r2d2::Pool;
+use r2d2_postgres::{PostgresConnectionManager, TlsMode};
+use std::env;
 
 fn main() {
     let mut app = Nickel::new();
 
     let postgres_url = env::var("DATABASE_URL").unwrap();
-    let db_mgr = PostgresConnectionManager::new(postgres_url.as_ref(), SslMode::None)
+    let db_mgr = PostgresConnectionManager::new(postgres_url.as_ref(), TlsMode::None)
         .expect("Unable to connect to database");
 
-    let db_pool = Pool::new(Config::default(), db_mgr)
-        .expect("Unable to initialize connection pool");
+    let db_pool = Pool::new(db_mgr).expect("Unable to initialize connection pool");
 
     app.utilize(PostgresMiddleware::with_pool(db_pool));
 
-    app.get("/my_counter", middleware! { |request, response|
-        let _connection = try_with!(response, request.pg_conn());
+    app.get(
+        "/my_counter",
+        middleware! { |request, response|
+            let _connection = try_with!(response, request.pg_conn());
 
-        // use connection
-    });
+            // use connection
+        },
+    );
 
     app.get("**", middleware! { println!("!!!") });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 extern crate nickel;
+extern crate plugin;
 extern crate r2d2;
 extern crate r2d2_postgres;
 extern crate typemap;
-extern crate plugin;
 
-pub use middleware::{ PostgresMiddleware, PostgresRequestExtensions };
+// pub use middleware::{ PostgresMiddleware, PostgresRequestExtensions };
 
 mod middleware;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,6 @@ extern crate r2d2;
 extern crate r2d2_postgres;
 extern crate typemap;
 
-// pub use middleware::{ PostgresMiddleware, PostgresRequestExtensions };
+pub use middleware::{PostgresMiddleware, PostgresRequestExtensions};
 
 mod middleware;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -19,7 +19,7 @@ impl PostgresMiddleware {
     pub fn new(db_url: &str) -> Result<PostgresMiddleware, Box<dyn Error>> {
         let manager = (PostgresConnectionManager::new(db_url, TlsMode::None))?;
         let pool = Pool::new(manager);
-        // pool.ok();
+
         Ok(PostgresMiddleware {
             pool: pool.ok().unwrap(),
         })


### PR DESCRIPTION
Deprecated libraries caused errors with newer rust version on windows. Changed deprecated pool creation, removed `GetTimeout` because it became obsolete, instead now it uses `r2d2::Error`, also changed `SslMode` to newer `TlsMode`. Other things stay as they are.